### PR TITLE
Use loop instead of KeIpiGenericCall

### DIFF
--- a/VirtualDbg/VM/Vm.cpp
+++ b/VirtualDbg/VM/Vm.cpp
@@ -50,7 +50,18 @@ VOID VmStart(PVOID StartContext)
 	//
 	DbgLog("Virtualizing %d processors...\n", KeNumberProcessors);
 
-	KeIpiGenericCall(IpiStartVirtualization, 0);
+	for (ULONG i = 0; i < (ULONG)KeNumberProcessors; i++)
+	{
+		KAFFINITY OldAffinity = KeSetSystemAffinityThreadEx((KAFFINITY)(1 << i));
+
+		KIRQL OldIrql = KeRaiseIrqlToDpcLevel();
+
+		_StartVirtualization();
+
+		KeLowerIrql(OldIrql);
+
+		KeRevertToUserAffinityThreadEx(OldAffinity);
+	}
 
 	DbgLog("Done\n");
 

--- a/VirtualDbg/VM/Vm.h
+++ b/VirtualDbg/VM/Vm.h
@@ -3,5 +3,4 @@
 VOID VmStart(PVOID StartContext);
 CHAR VmIsActive();
 
-ULONG_PTR IpiStartVirtualization(ULONG_PTR Argument);
 NTSTATUS StartVirtualization(PVOID GuestRsp);


### PR DESCRIPTION
when system function `KeIpiGenericCall()` is called, it will set IRQL to `IPI_LEVEL`,which is much higher than `DISPATCH_LEVEL` so that memory allocation may fail.

https://msdn.microsoft.com/en-us/library/windows/hardware/ff552198(v=vs.85).aspx

In MSDN, `MmAllocateContiguousMemorySpecifyCache`should be called at IRQL <= DISPATCH_LEVEL.
https://msdn.microsoft.com/en-us/library/windows/hardware/ff554464(v=vs.85).aspx

On Windows 10 x64 codes below run well.
